### PR TITLE
fix: update booking status display to show 'Cancelled' instead of 'nled'

### DIFF
--- a/Components/booking-history/history-list.js
+++ b/Components/booking-history/history-list.js
@@ -382,7 +382,7 @@ const BookingHistory = () => {
                   : booking.booking_status === "Cancelled" &&
                     booking.payment_status === null
                   ? "Expired"
-                  : "nled"}
+                  : "Cancelled"}
               </div>
             </div>
 


### PR DESCRIPTION
fix typo