### PR TITLE
fix: corrected typo in booking history component

### DIFF
--- a/Components/booking-history/history-list.js
+++ b/Components/booking-history/history-list.js
@@ -416,7 +416,7 @@ const BookingHistory = () => {
                 >
                   <div className="flex justify-between items-center h-[50px] px-6 py-3 ">
                     <div className="text-xl font-bold w-[64px]"></div>
-                    <span className="text-white">Booking Deatail</span>
+                    <span className="text-white">Booking Detail</span>
 
                     <div className="flex gap-4 w-[64px]">
                       <button


### PR DESCRIPTION
Fix Typo on Booking History modal Title on Head.
![image](https://github.com/user-attachments/assets/0b8a6eb5-1f7a-4346-b7de-9f07e95f606d)
